### PR TITLE
fix: output details

### DIFF
--- a/modules/organizations/outputs.tf
+++ b/modules/organizations/outputs.tf
@@ -24,6 +24,12 @@ output "details" {
   depends_on = [
     time_sleep.organization_setup
   ]
-  value       = harness_platform_organization.organization
+  value = (
+    var.existing
+    ?
+    data.harness_platform_organization.selected[0]
+    :
+    harness_platform_organization.organization[0]
+  )
   description = "Details for the created Harness Organization"
 }

--- a/modules/projects/outputs.tf
+++ b/modules/projects/outputs.tf
@@ -24,6 +24,12 @@ output "details" {
   depends_on = [
     time_sleep.project_setup
   ]
-  value       = harness_platform_project.project
+  value = (
+    var.existing
+    ?
+    data.harness_platform_project.selected[0]
+    :
+    harness_platform_project.project[0]
+  )
   description = "Details for the created Harness Project"
 }


### PR DESCRIPTION
bug: the new `details` output actaully works like `module.this.details[0].id` instead of `module.this.details.id` as you would expect. also dosnt support existing resources. this fixes that.

when migrating an organization created by this module from the current 0.1.1 version to this version, it will break anything using the output, but wont delete any existing orgs, so should be safe for a 0.1.2 release.